### PR TITLE
AI: Initial support for openai/gpt-4o-mini

### DIFF
--- a/.github/workflows/AI.yml
+++ b/.github/workflows/AI.yml
@@ -31,15 +31,15 @@ jobs:
         id: set-matrix
         run: python scripts/scanner.py
 
-  # Job 2: Process files and create PRs per subject
+# Job 2: Process files and create PRs per subject
   process-and-pr:
     needs: scan-files
-    if: needs.scan-files.outputs.matrix != '[]'
+    if: needs.scan-files.outputs.matrix != '[]' && needs.scan-files.outputs.matrix != ''
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.scan.outputs.matrix) }}
+        include: ${{ fromJson(needs.scan-files.outputs.matrix) }}
         
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/AI.yml
+++ b/.github/workflows/AI.yml
@@ -1,0 +1,93 @@
+name: Clanker AI Update
+
+on:
+  workflow_dispatch:
+  #push:
+  #  paths:
+  #    - '**/*.md'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # Job 1: Scan for files requiring updates and group them by subject
+  scan-files:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          
+      - name: Install dependencies
+        run: pip install python-frontmatter pyyaml
+
+      - name: Scan and Build Matrix
+        id: set-matrix
+        run: python scripts/scanner.py
+
+  # Job 2: Process files and create PRs per subject
+  process-and-pr:
+    needs: scan-files
+    if: needs.scan-files.outputs.matrix != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.scan.outputs.matrix) }}
+        
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: pip install python-frontmatter pyyaml openai
+
+      - name: Authenticate with GitHub CLI
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
+      - name: Process Files for ${{ matrix.subcategory }}
+        env:
+          # Using GITHUB_TOKEN for free access if using GitHub Models, 
+          # otherwise add a repository secret named OPENAI_API_KEY
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_DIR: ${{ matrix.path }}
+        run: python scripts/processor.py
+
+      - name: Create Pull Request
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Configure Git
+          git config --global user.name "Clanker Bot"
+          git config --global user.email "clanker@users.noreply.github.com"
+          
+          # Create unique branch
+          BRANCH_NAME="clanker/${{ matrix.category }}-${{ matrix.subcategory }}-$(date +%s)"
+          git checkout -b $BRANCH_NAME
+          
+          # Commit changes
+          git add .
+          if git diff-index --quiet HEAD; then
+            echo "No changes to commit."
+          else
+            git commit -m "docs: AI updates for ${{ matrix.subcategory }}"
+            git push origin $BRANCH_NAME
+            
+            # Create PR
+            gh pr create \
+              --title "Clanker Update: ${{ matrix.subcategory }}" \
+              --body "Automated AI content generation for ${{ matrix.subcategory }}. Categories processed: ${{ matrix.category }}." \
+              --base contents \
+              --head $BRANCH_NAME
+          fi

--- a/.github/workflows/AI.yml
+++ b/.github/workflows/AI.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  models: read
 
 jobs:
   # Job 1: Scan for files requiring updates and group them by subject

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -1,0 +1,116 @@
+import os
+import re
+import frontmatter
+import subprocess
+import datetime
+from pathlib import Path
+
+# --- Master Prompt ---
+SYSTEM_PROMPT = """
+You are a helpful academic assistant. 
+1. Answer the user's question accurately.
+2. Skip diagrams unless they are Mermaid.js. Keep Mermaid diagrams short and simple.
+3. Formatting:
+   - Use #### (H4) headings and smaller. DO NOT use #, ##, or ###.
+   - Avoid HTML divs and spans unless absolutely necessary.
+   - Use Markdown for bolding and lists.
+4. Be concise.
+5. Keep in mind that the text will be fed to Vitepress. 
+6. Code highlighting will be done with shiki. 
+"""
+
+def call_gh_copilot(prompt):
+    """
+    Uses GitHub CLI to generate text. 
+    Assumes `gh` is authenticated in the workflow.
+    Falls back to a mock if gh model fails (for safety).
+    """
+    full_prompt = f"{SYSTEM_PROMPT}\n\nTask: {prompt}"
+    
+    try:
+        # Trying to use gh model (if 'models' extension is installed or built-in)
+        # Using standard GPT-4o-mini for cost/speed efficiency if available
+        cmd = ["gh", "model", "prompt", full_prompt] 
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        
+        if result.returncode == 0:
+            return result.stdout.strip()
+        else:
+            # Fallback: simple echo for debugging if API fails/not configured
+            print(f"GH Model failed: {result.stderr}")
+            return ""
+    except Exception as e:
+        return f""
+
+def process_file(filepath):
+    post = frontmatter.load(filepath)
+    content = post.content
+    original_content = content
+    
+    # Regex to find: use-AI-here-please: "some text"
+    # Matches both: use-AI-here-please: "prompt" AND use-AI-here-please
+    pattern = re.compile(r'use-AI-here-please(?::\s*"(.*?)")?', re.IGNORECASE)
+    
+    matches = list(pattern.finditer(content))
+    
+    # Iterate backwards to avoid index shifting issues during replacement
+    for match in reversed(matches):
+        full_match = match.group(0)
+        user_prompt = match.group(1)
+        
+        if not user_prompt:
+            # If no specific prompt, look at context or use default
+            user_prompt = "Explain the concept related to this section."
+
+        print(f"Generating for: {user_prompt[:30]}... in {filepath}")
+        
+        ai_response = call_gh_copilot(user_prompt)
+        
+        # Generate Disclaimer
+        date_str = datetime.datetime.now().strftime("%Y-%m-%d")
+        disclaimer = f"\n\n<sub>This was AI generated from github copilot on {date_str}</sub>\n"
+        
+        replacement = f"\n{ai_response}\n{disclaimer}\n"
+        
+        # Replace the tag with response
+        start, end = match.span()
+        content = content[:start] + replacement + content[end:]
+
+    # Check if we made changes
+    if content != original_content:
+        post.content = content
+        
+        # Cleanup: Check if any use-AI tags remain. If not, remove frontmatter key.
+        if not pattern.search(content):
+            if 'use-AI-here-please' in post.metadata:
+                del post.metadata['use-AI-here-please']
+            # Note: We keep 'clanker: true' so we know this file is tracked, 
+            # unless you strictly want it removed too.
+            # Uncomment below to remove clanker trigger when completely done:
+            # if 'clanker' in post.metadata:
+            #     del post.metadata['clanker']
+
+        # Write back to file
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write(frontmatter.dumps(post))
+        print(f"Updated {filepath}")
+
+def main():
+    target_dir = os.environ.get("TARGET_DIR", ".")
+    print(f"Processing directory: {target_dir}")
+    
+    for root, dirs, files in os.walk(target_dir):
+        for file in files:
+            if file.endswith(".md"):
+                fp = os.path.join(root, file)
+                
+                # Double check frontmatter before processing
+                try:
+                    fm = frontmatter.load(fp)
+                    if fm.get('clanker') is True:
+                        process_file(fp)
+                except:
+                    continue
+
+if __name__ == "__main__":
+    main()

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -21,8 +21,11 @@ You are a technical academic assistant.
    - Do NOT use HTML tags unless strictly necessary.
 3. DIAGRAMS: 
    - Skip visual diagrams/ASCII art. 
-   - You may use 'mermaid' code blocks for simple diagrams.
-4. TONE: Concise, technical, and direct.
+   - You are encouraged to use 'mermaid' code blocks for simple diagrams especially if it increases the quality of the answer.
+   - You may use any diagram type supported by vitepress-plugin-mermaid like Default flowcharts, Pie chart, Gantt Chart, Mindmap.
+4. TONE: Concise, technical, and direct. Explain simplistically while using accurate terms.
+5. LENGTH: Generally short. Keep it easy for a student to refer and write without increasing too much burden.
+6. CODE: Keep shiki compatibility in mind for code highlighting. If algorithms is a core focus of the code, generate time and space complexity in correct LaTeX form. 
 """
 
 def get_ai_client():

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -1,51 +1,72 @@
 import os
 import re
 import frontmatter
-import subprocess
 import datetime
 import sys
+from openai import OpenAI
 
 # --- Configuration ---
-# This system prompt ensures the AI outputs the exact format you want.
+# GitHub Models Endpoint
+ENDPOINT = "https://models.github.ai/inference"
+# Using gpt-4o-mini as it is efficient and less likely to hit strict rate limits than full GPT-4
+MODEL_NAME = "gpt-4o-mini" 
+
 SYSTEM_PROMPT = """
 You are a technical academic assistant.
-1. ACTION: specific answer to the user's prompt.
+1. ACTION: Answer the user's specific prompt accurately.
 2. FORMATTING: 
    - Use Markdown. 
    - Use #### (H4) or ##### (H5) for headings. 
    - NEVER use # (H1), ## (H2), or ### (H3).
-   - Do NOT use HTML tags (<div>, <span>) unless strictly necessary.
+   - Do NOT use HTML tags unless strictly necessary.
 3. DIAGRAMS: 
    - Skip visual diagrams/ASCII art. 
-   - You may use 'mermaid' code blocks for diagrams if they are simple.
+   - You may use 'mermaid' code blocks for simple diagrams.
 4. TONE: Concise, technical, and direct.
-5. CODE: Feel free to include snippets that are short enough to represent the answer. 
 """
 
-def call_gh_model(prompt):
+def get_ai_client():
     """
-    Sends ONLY the specific prompt string to GitHub Models/Copilot.
+    Initializes the OpenAI client pointing to GitHub Models.
+    Requires GITHUB_TOKEN in environment variables.
     """
-    full_prompt = f"{SYSTEM_PROMPT}\n\nUser Question: {prompt}"
-    
-    try:
-        # We use 'gh model' to keep it within the free/beta tier constraints
-        # Ensure 'gh extension install github/gh-models' is run in workflow
-        cmd = ["gh", "model", "prompt", "-m", "gpt-4o-mini", full_prompt] 
-        
-        # Subprocess to catch stdout
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        
-        if result.returncode == 0:
-            return result.stdout.strip()
-        else:
-            print(f"API Error: {result.stderr}", file=sys.stderr)
-            return f"> **Error:** AI generation failed. Details: {result.stderr}"
-    except Exception as e:
-        return f"> **Error:** Script failed to invoke AI. {str(e)}"
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        print("Error: GITHUB_TOKEN or GH_TOKEN not found.", file=sys.stderr)
+        return None
 
-def process_file(filepath):
-    # Load the file
+    return OpenAI(
+        base_url=ENDPOINT,
+        api_key=token,
+    )
+
+def call_github_model(client, prompt):
+    """
+    Sends ONLY the specific prompt string to GitHub Models using OpenAI SDK.
+    """
+    try:
+        response = client.chat.completions.create(
+            messages=[
+                {
+                    "role": "system",
+                    "content": SYSTEM_PROMPT,
+                },
+                {
+                    "role": "user",
+                    "content": prompt,
+                }
+            ],
+            temperature=0.7, # Slightly lower for more academic/consistent results
+            top_p=1.0,
+            max_tokens=1000, # Safety cap to prevent large output eating into rate limits
+            model=MODEL_NAME
+        )
+        return response.choices[0].message.content
+    except Exception as e:
+        print(f"API Error: {e}", file=sys.stderr)
+        return f"> **Error:** AI generation failed. Details: {str(e)}"
+
+def process_file(client, filepath):
     try:
         post = frontmatter.load(filepath)
     except Exception as e:
@@ -56,72 +77,67 @@ def process_file(filepath):
     original_content = content
     
     # Regex to find: use-AI-here-please: "some text"
-    # Capture group 1 is the prompt text inside the quotes.
     pattern = re.compile(r'use-AI-here-please:\s*"(.*?)"', re.IGNORECASE)
-    
-    # Find all matches
     matches = list(pattern.finditer(content))
     
     if not matches:
-        print(f"No specific tags found in {filepath}")
         return
 
     print(f"Found {len(matches)} tags in {filepath}...")
 
-    # Iterate backwards so replacing text doesn't mess up character indices of earlier matches
+    # Iterate backwards for safe substitution
     for match in reversed(matches):
         prompt_text = match.group(1)
-        full_match_text = match.group(0)
         
         print(f"  - Processing: '{prompt_text[:40]}...'")
         
-        # 1. Call AI with ONLY the prompt text
-        ai_response = call_gh_model(prompt_text)
+        # 1. Call AI
+        ai_response = call_github_model(client, prompt_text)
         
-        # 2. Build the Disclaimer
+        # 2. Build Disclaimer
         date_str = datetime.datetime.now().strftime("%Y-%m-%d")
         disclaimer = f"\n<sub>This was AI generated from github copilot on {date_str}</sub>"
         
-        # 3. Create the replacement block
-        # We add newlines to ensure markdown renders correctly
+        # 3. Create Replacement
         replacement_block = f"\n{ai_response}\n{disclaimer}\n"
         
-        # 4. PYTHON performs the substitution locally
-        start_index, end_index = match.span()
-        content = content[:start_index] + replacement_block + content[end_index:]
+        # 4. Substitute
+        start, end = match.span()
+        content = content[:start] + replacement_block + content[end:]
 
-    # Save changes if modifications happened
+    # Save changes if any
     if content != original_content:
         post.content = content
         
-        # Cleanup: Remove the trigger from frontmatter if no tags remain
-        # (We check specifically for the tag string to ensure we didn't miss any)
+        # Cleanup frontmatter if all tags are gone
         if "use-AI-here-please:" not in content:
             if 'use-AI-here-please' in post.metadata:
                 del post.metadata['use-AI-here-please']
-                print("  - Removed frontmatter trigger key.")
 
-        # Write back to file
         with open(filepath, 'w', encoding='utf-8') as f:
             f.write(frontmatter.dumps(post))
         print(f"  - File updated successfully.")
 
 def main():
-    # The workflow passes the target directory via env var
     target_dir = os.environ.get("TARGET_DIR", ".")
     print(f"Processor starting in: {target_dir}")
+    
+    # Initialize Client once
+    client = get_ai_client()
+    if not client:
+        sys.exit(1)
     
     for root, dirs, files in os.walk(target_dir):
         for file in files:
             if file.endswith(".md"):
                 fp = os.path.join(root, file)
                 
-                # Check for the clanker flag before opening heavy logic
+                # Light check for clanker flag
                 try:
                     with open(fp, 'r', encoding='utf-8') as f:
-                        header = f.read(500) # Read just the top
+                        header = f.read(500)
                     if 'clanker: true' in header:
-                        process_file(fp)
+                        process_file(client, fp)
                 except:
                     continue
 

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -9,7 +9,7 @@ from openai import OpenAI
 # GitHub Models Endpoint
 ENDPOINT = "https://models.github.ai/inference"
 # Using gpt-4o-mini as it is efficient and less likely to hit strict rate limits than full GPT-4
-MODEL_NAME = "gpt-4o-mini" 
+MODEL_NAME = "openai/gpt-4o-mini" 
 
 SYSTEM_PROMPT = """
 You are a technical academic assistant.

--- a/scripts/processor.py
+++ b/scripts/processor.py
@@ -3,111 +3,124 @@ import re
 import frontmatter
 import subprocess
 import datetime
-from pathlib import Path
+import sys
 
-# --- Master Prompt ---
+# --- Configuration ---
+# This system prompt ensures the AI outputs the exact format you want.
 SYSTEM_PROMPT = """
-You are a helpful academic assistant. 
-1. Answer the user's question accurately.
-2. Skip diagrams unless they are Mermaid.js. Keep Mermaid diagrams short and simple.
-3. Formatting:
-   - Use #### (H4) headings and smaller. DO NOT use #, ##, or ###.
-   - Avoid HTML divs and spans unless absolutely necessary.
-   - Use Markdown for bolding and lists.
-4. Be concise.
-5. Keep in mind that the text will be fed to Vitepress. 
-6. Code highlighting will be done with shiki. 
+You are a technical academic assistant.
+1. ACTION: specific answer to the user's prompt.
+2. FORMATTING: 
+   - Use Markdown. 
+   - Use #### (H4) or ##### (H5) for headings. 
+   - NEVER use # (H1), ## (H2), or ### (H3).
+   - Do NOT use HTML tags (<div>, <span>) unless strictly necessary.
+3. DIAGRAMS: 
+   - Skip visual diagrams/ASCII art. 
+   - You may use 'mermaid' code blocks for diagrams if they are simple.
+4. TONE: Concise, technical, and direct.
+5. CODE: Feel free to include snippets that are short enough to represent the answer. 
 """
 
-def call_gh_copilot(prompt):
+def call_gh_model(prompt):
     """
-    Uses GitHub CLI to generate text. 
-    Assumes `gh` is authenticated in the workflow.
-    Falls back to a mock if gh model fails (for safety).
+    Sends ONLY the specific prompt string to GitHub Models/Copilot.
     """
-    full_prompt = f"{SYSTEM_PROMPT}\n\nTask: {prompt}"
+    full_prompt = f"{SYSTEM_PROMPT}\n\nUser Question: {prompt}"
     
     try:
-        # Trying to use gh model (if 'models' extension is installed or built-in)
-        # Using standard GPT-4o-mini for cost/speed efficiency if available
-        cmd = ["gh", "model", "prompt", full_prompt] 
+        # We use 'gh model' to keep it within the free/beta tier constraints
+        # Ensure 'gh extension install github/gh-models' is run in workflow
+        cmd = ["gh", "model", "prompt", "-m", "gpt-4o-mini", full_prompt] 
+        
+        # Subprocess to catch stdout
         result = subprocess.run(cmd, capture_output=True, text=True)
         
         if result.returncode == 0:
             return result.stdout.strip()
         else:
-            # Fallback: simple echo for debugging if API fails/not configured
-            print(f"GH Model failed: {result.stderr}")
-            return ""
+            print(f"API Error: {result.stderr}", file=sys.stderr)
+            return f"> **Error:** AI generation failed. Details: {result.stderr}"
     except Exception as e:
-        return f""
+        return f"> **Error:** Script failed to invoke AI. {str(e)}"
 
 def process_file(filepath):
-    post = frontmatter.load(filepath)
+    # Load the file
+    try:
+        post = frontmatter.load(filepath)
+    except Exception as e:
+        print(f"Skipping {filepath}: invalid frontmatter")
+        return
+
     content = post.content
     original_content = content
     
     # Regex to find: use-AI-here-please: "some text"
-    # Matches both: use-AI-here-please: "prompt" AND use-AI-here-please
-    pattern = re.compile(r'use-AI-here-please(?::\s*"(.*?)")?', re.IGNORECASE)
+    # Capture group 1 is the prompt text inside the quotes.
+    pattern = re.compile(r'use-AI-here-please:\s*"(.*?)"', re.IGNORECASE)
     
+    # Find all matches
     matches = list(pattern.finditer(content))
     
-    # Iterate backwards to avoid index shifting issues during replacement
+    if not matches:
+        print(f"No specific tags found in {filepath}")
+        return
+
+    print(f"Found {len(matches)} tags in {filepath}...")
+
+    # Iterate backwards so replacing text doesn't mess up character indices of earlier matches
     for match in reversed(matches):
-        full_match = match.group(0)
-        user_prompt = match.group(1)
+        prompt_text = match.group(1)
+        full_match_text = match.group(0)
         
-        if not user_prompt:
-            # If no specific prompt, look at context or use default
-            user_prompt = "Explain the concept related to this section."
-
-        print(f"Generating for: {user_prompt[:30]}... in {filepath}")
+        print(f"  - Processing: '{prompt_text[:40]}...'")
         
-        ai_response = call_gh_copilot(user_prompt)
+        # 1. Call AI with ONLY the prompt text
+        ai_response = call_gh_model(prompt_text)
         
-        # Generate Disclaimer
+        # 2. Build the Disclaimer
         date_str = datetime.datetime.now().strftime("%Y-%m-%d")
-        disclaimer = f"\n\n<sub>This was AI generated from github copilot on {date_str}</sub>\n"
+        disclaimer = f"\n<sub>This was AI generated from github copilot on {date_str}</sub>"
         
-        replacement = f"\n{ai_response}\n{disclaimer}\n"
+        # 3. Create the replacement block
+        # We add newlines to ensure markdown renders correctly
+        replacement_block = f"\n{ai_response}\n{disclaimer}\n"
         
-        # Replace the tag with response
-        start, end = match.span()
-        content = content[:start] + replacement + content[end:]
+        # 4. PYTHON performs the substitution locally
+        start_index, end_index = match.span()
+        content = content[:start_index] + replacement_block + content[end_index:]
 
-    # Check if we made changes
+    # Save changes if modifications happened
     if content != original_content:
         post.content = content
         
-        # Cleanup: Check if any use-AI tags remain. If not, remove frontmatter key.
-        if not pattern.search(content):
+        # Cleanup: Remove the trigger from frontmatter if no tags remain
+        # (We check specifically for the tag string to ensure we didn't miss any)
+        if "use-AI-here-please:" not in content:
             if 'use-AI-here-please' in post.metadata:
                 del post.metadata['use-AI-here-please']
-            # Note: We keep 'clanker: true' so we know this file is tracked, 
-            # unless you strictly want it removed too.
-            # Uncomment below to remove clanker trigger when completely done:
-            # if 'clanker' in post.metadata:
-            #     del post.metadata['clanker']
+                print("  - Removed frontmatter trigger key.")
 
         # Write back to file
         with open(filepath, 'w', encoding='utf-8') as f:
             f.write(frontmatter.dumps(post))
-        print(f"Updated {filepath}")
+        print(f"  - File updated successfully.")
 
 def main():
+    # The workflow passes the target directory via env var
     target_dir = os.environ.get("TARGET_DIR", ".")
-    print(f"Processing directory: {target_dir}")
+    print(f"Processor starting in: {target_dir}")
     
     for root, dirs, files in os.walk(target_dir):
         for file in files:
             if file.endswith(".md"):
                 fp = os.path.join(root, file)
                 
-                # Double check frontmatter before processing
+                # Check for the clanker flag before opening heavy logic
                 try:
-                    fm = frontmatter.load(fp)
-                    if fm.get('clanker') is True:
+                    with open(fp, 'r', encoding='utf-8') as f:
+                        header = f.read(500) # Read just the top
+                    if 'clanker: true' in header:
                         process_file(fp)
                 except:
                     continue

--- a/scripts/scanner.py
+++ b/scripts/scanner.py
@@ -1,0 +1,55 @@
+import os
+import frontmatter
+import json
+import sys
+
+def scan_files():
+    matrix_data = {}
+    
+    # Walk through the directory
+    for root, dirs, files in os.walk("."):
+        if ".git" in root:
+            continue
+            
+        for file in files:
+            if file.endswith(".md"):
+                filepath = os.path.join(root, file)
+                try:
+                    post = frontmatter.load(filepath)
+                    
+                    # Check for explicit clanker: true
+                    if post.get('clanker') is True:
+                        # Check if "use-AI-here-please" exists in content text
+                        if "use-AI-here-please" in post.content:
+                            
+                            # Parse Path structure: ./3rdsem/SubjectName/file.md
+                            parts = os.path.normpath(filepath).split(os.sep)
+                            
+                            if len(parts) >= 3:
+                                category = parts[1] # e.g., 3rdsem
+                                subcategory = parts[2] # e.g., Computer-Communications-Networks
+                                
+                                key = f"{category}/{subcategory}"
+                                
+                                if key not in matrix_data:
+                                    matrix_data[key] = {
+                                        "category": category,
+                                        "subcategory": subcategory,
+                                        "path": os.path.join(category, subcategory)
+                                    }
+                except Exception as e:
+                    print(f"Error parsing {filepath}: {e}", file=sys.stderr)
+
+    # Convert to list for GitHub Actions Matrix
+    output_list = list(matrix_data.values())
+    
+    # Print JSON to stdout for GITHUB_OUTPUT
+    print(f"matrix={json.dumps(output_list)}")
+    
+    # Append to GITHUB_OUTPUT environment file
+    if os.getenv('GITHUB_OUTPUT'):
+        with open(os.getenv('GITHUB_OUTPUT'), 'a') as f:
+            f.write(f"matrix={json.dumps(output_list)}\n")
+
+if __name__ == "__main__":
+    scan_files()

--- a/scripts/scanner.py
+++ b/scripts/scanner.py
@@ -8,48 +8,50 @@ def scan_files():
     
     # Walk through the directory
     for root, dirs, files in os.walk("."):
-        if ".git" in root:
+        if ".git" in root or ".github" in root:
             continue
             
         for file in files:
             if file.endswith(".md"):
                 filepath = os.path.join(root, file)
                 try:
+                    # Load frontmatter to check for triggers
                     post = frontmatter.load(filepath)
                     
-                    # Check for explicit clanker: true
-                    if post.get('clanker') is True:
-                        # Check if "use-AI-here-please" exists in content text
-                        if "use-AI-here-please" in post.content:
+                    if post.get('clanker') is True and "use-AI-here-please" in post.content:
+                        # Normalize path to handle Windows/Linux separators
+                        norm_path = os.path.normpath(filepath)
+                        parts = norm_path.split(os.sep)
+                        
+                        # Expected Structure: 3rdsem / SubjectName / Type / file.md
+                        # We want to group by Subject (parts[0]/parts[1])
+                        if len(parts) >= 2:
+                            semester = parts[0]  # e.g., 3rdsem
+                            subject = parts[1]   # e.g., Computer-Communications-Networks
                             
-                            # Parse Path structure: ./3rdsem/SubjectName/file.md
-                            parts = os.path.normpath(filepath).split(os.sep)
+                            # Unique key for the Pull Request
+                            key = f"{semester}/{subject}"
                             
-                            if len(parts) >= 3:
-                                category = parts[1] # e.g., 3rdsem
-                                subcategory = parts[2] # e.g., Computer-Communications-Networks
-                                
-                                key = f"{category}/{subcategory}"
-                                
-                                if key not in matrix_data:
-                                    matrix_data[key] = {
-                                        "category": category,
-                                        "subcategory": subcategory,
-                                        "path": os.path.join(category, subcategory)
-                                    }
+                            if key not in matrix_data:
+                                matrix_data[key] = {
+                                    "category": semester,
+                                    "subcategory": subject,
+                                    # Use the path up to the subject so we scan recursively inside the subject
+                                    "path": os.path.join(semester, subject)
+                                }
                 except Exception as e:
                     print(f"Error parsing {filepath}: {e}", file=sys.stderr)
 
-    # Convert to list for GitHub Actions Matrix
     output_list = list(matrix_data.values())
+    output_json = json.dumps(output_list)
     
-    # Print JSON to stdout for GITHUB_OUTPUT
-    print(f"matrix={json.dumps(output_list)}")
+    # Debug print to see what it found
+    print(f"Generated Matrix: {output_json}")
     
     # Append to GITHUB_OUTPUT environment file
     if os.getenv('GITHUB_OUTPUT'):
         with open(os.getenv('GITHUB_OUTPUT'), 'a') as f:
-            f.write(f"matrix={json.dumps(output_list)}\n")
+            f.write(f"matrix={output_json}\n")
 
 if __name__ == "__main__":
     scan_files()


### PR DESCRIPTION
The repository now supports generating content automatically for the repository. 

This comes in the form of a pull-request for a subject. 

You can initiate this by including `clanker: true` in a markdown file's frontmatter like this.

```
---
clanker: true
---
```
You can also specify the point which you want to insert the generation into, with `use-AI-here-please`

Example:
```
use-AI-here-please: "generate a short, simple explanation on what DFS and BFS is in under 2 paragraphs. Introduce a differences table for markdown and finish it with step by step TD mermaid example."
```

When AI is used, it will leave a notice like <sub>This was AI generated from github copilot on 2025-12-09</sub>

The intention is to fill gaps before exams. 